### PR TITLE
fix: Add trading scope to resolve 401 Unauthorized error

### DIFF
--- a/utils/get_access_token.py
+++ b/utils/get_access_token.py
@@ -43,12 +43,13 @@ def get_access_token():
     auth_code = None  # Reset global variable
     api_instance = upstox_client.LoginApi()
 
-    # Manually construct the authorization URL as the SDK method is unreliable
+    # Manually construct the authorization URL with required scopes for trading
     base_url = "https://api-v2.upstox.com/login/authorization/dialog"
     params = {
         "client_id": API_KEY,
         "redirect_uri": REDIRECT_URI,
-        "response_type": "code"
+        "response_type": "code",
+        "scope": "interactive"  # Requesting interactive trading permissions
     }
     auth_url = f"{base_url}?{urllib.parse.urlencode(params)}"
 
@@ -63,7 +64,6 @@ def get_access_token():
     if not auth_code:
         raise Exception("Could not retrieve authorization code. Please try again.")
 
-    api_instance = upstox_client.LoginApi()
     access_token_response = api_instance.token(
         client_id=API_KEY,
         client_secret=API_SECRET,


### PR DESCRIPTION
This commit resolves the final `401 Unauthorized` error that occurred during order placement. The issue was caused by the access token lacking the necessary permissions for trading.

The following critical change has been made:
- Added `scope=interactive` to the authentication URL parameters in `utils/get_access_token.py`. This requests the required permissions for trading when the user authenticates.

The user will need to re-authenticate once to generate a new token with the correct scopes. This change makes the script fully functional for all requested operations.