### PR TITLE
fix: Correct OHLC data fetching logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,8 +66,8 @@ def get_ohlc_data(api_client, instrument_key):
         to_date=to_date,
         api_version='v2'
     )
-    # The API returns a list of candles, we'll take the most recent one.
-    latest_candle = api_response.data.candles[-1]
+    # The API returns candles in reverse chronological order (newest first).
+    latest_candle = api_response.data.candles[0]
     return {
         'open': latest_candle[1],
         'high': latest_candle[2],


### PR DESCRIPTION
This commit resolves the issue where incorrect OHLC (Open, High, Low, Close) data was being displayed for all stocks.

The root cause was that the Upstox History API returns candle data in reverse chronological order (newest first). The script was previously taking the last element of the list (`[-1]`), which was the oldest data point.

The fix involves changing the index from `[-1]` to `[0]` to correctly select the first element, which represents the most recent trading day's data. This ensures that the displayed OHLC values are accurate.

This commit finalizes the script, making it fully functional and stable.