### PR TITLE
fix(webapp): Clarify calculator's final share count label

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -323,7 +323,7 @@
                         <p><span class="label">Investment Period:</span> ${result.start_date} to ${result.end_date}</p>
                         <p><span class="label">Starting Price:</span> ₹${result.start_price.toFixed(2)}</p>
                         <p><span class="label">Ending Price:</span> ₹${result.end_price.toFixed(2)}</p>
-                        <p><span class="label">Final Share Count (adjusted for splits/dividends):</span> ${result.total_shares}</p>
+                        <p><span class="label">Final Share Count (after reinvesting dividends):</span> ${result.total_shares}</p>
                     `;
                 } else {
                     calculatorResultDiv.innerHTML = `<p style="color: red;">Error: ${result.error}</p>`;


### PR DESCRIPTION
This commit updates the text label for the 'Final Share Count' in the investment calculator's result display.

The previous label, 'Final Share Count (adjusted for splits/dividends)', was confusing because the data source is already adjusted for splits.

The new label, 'Final Share Count (after reinvesting dividends)', more accurately describes how the final share count is calculated, reflecting the growth from reinvested dividend payouts. This provides better clarity for the user.