### PR TITLE
feat(webapp): Add date range selection to calculator

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -60,16 +60,17 @@ def calculate_investment():
     data = request.get_json()
     symbol = data.get('symbol')
     investment_amount = float(data.get('amount'))
-    start_date = data.get('date')
+    from_date = data.get('from_date')
+    to_date = data.get('to_date')
 
-    if not all([symbol, investment_amount, start_date]):
+    if not all([symbol, investment_amount, from_date, to_date]):
         return jsonify({"error": "Missing required parameters"}), 400
 
     conn = get_db_connection()
-    # Fetch all data for the stock from the start date
+    # Fetch all data for the stock within the specified date range
     history = conn.execute(
-        "SELECT date, open, high, low, close, action_type, value FROM merged_data WHERE stock = ? AND date >= ? ORDER BY date",
-        (symbol.upper(), start_date)
+        "SELECT date, open, high, low, close, action_type, value FROM merged_data WHERE stock = ? AND date BETWEEN ? AND ? ORDER BY date",
+        (symbol.upper(), from_date, to_date)
     ).fetchall()
     conn.close()
 

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -69,8 +69,12 @@
                 <input type="number" id="calc-amount" min="1" required>
             </div>
             <div class="form-group">
-                <label for="calc-date">Investment Date:</label>
-                <input type="date" id="calc-date" required>
+                <label for="calc-from-date">From Date:</label>
+                <input type="date" id="calc-from-date" required>
+            </div>
+            <div class="form-group">
+                <label for="calc-to-date">To Date:</label>
+                <input type="date" id="calc-to-date" required>
             </div>
             <button type="submit">Calculate</button>
         </form>
@@ -339,13 +343,17 @@
         const calculatorForm = document.getElementById('calculator-form');
         const calculatorResultDiv = document.getElementById('calculator-result');
 
+        // Set default 'To Date' to today
+        document.getElementById('calc-to-date').value = new Date().toISOString().split('T')[0];
+
         calculatorForm.addEventListener('submit', async (event) => {
             event.preventDefault();
             calculatorResultDiv.innerHTML = '<p>Calculating...</p>';
 
             const symbol = document.getElementById('calc-stock-symbol').value;
             const amount = document.getElementById('calc-amount').value;
-            const date = document.getElementById('calc-date').value;
+            const from_date = document.getElementById('calc-from-date').value;
+            const to_date = document.getElementById('calc-to-date').value;
 
             try {
                 const response = await fetch('/api/calculate_investment', {
@@ -353,7 +361,7 @@
                     headers: {
                         'Content-Type': 'application/json',
                     },
-                    body: JSON.stringify({ symbol, amount, date }),
+                    body: JSON.stringify({ symbol, amount, from_date, to_date }),
                 });
 
                 const result = await response.json();


### PR DESCRIPTION
This commit enhances the investment calculator by allowing users to specify a custom date range for their calculations.

1.  **UI Update:**
    - The calculator form in `webapp/templates/index.html` now includes separate "From Date" and "To Date" input fields.
    - The "To Date" field defaults to the current date for user convenience.

2.  **Backend Update:**
    - The `/api/calculate_investment` endpoint in `webapp/app.py` has been modified to accept `from_date` and `to_date` parameters.
    - The database query now uses a `BETWEEN` clause to fetch historical data only within the specified range.

3.  **Frontend Logic:**
    - The JavaScript that handles the calculator form submission has been updated to read the values from the new date inputs and send them to the backend API.