### PR TITLE
fix(webapp): Correct NameError by moving os import

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, jsonify, render_template, request, redirect, url_for, flash
 import sqlite3
+import os
 from datetime import datetime
 from werkzeug.security import generate_password_hash, check_password_hash
 from flask_login import LoginManager, UserMixin, login_user, logout_user, login_required, current_user
@@ -72,8 +73,6 @@ def register():
 def logout():
     logout_user()
     return redirect(url_for('login'))
-
-import os
 
 # Database setup
 # In a production environment (like Render), set the DATABASE_URL environment variable


### PR DESCRIPTION
This commit fixes a `NameError` that occurred because the 'os' module was used before it was imported. The `import os` statement has been moved to the top of `webapp/app.py` with the other imports to resolve the issue. This ensures the module is available when its methods are called for reading environment variables, preventing the application from crashing on startup.